### PR TITLE
Implement Material Design UI

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,4 @@
+/* Custom tweaks for layout */
+.page-content {
+    padding: 20px;
+}

--- a/templates/assignment_detail.html
+++ b/templates/assignment_detail.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>{{ assignment.title }}</h2>
+<h2 class="mdl-typography--display-1">{{ assignment.title }}</h2>
 <p>{{ assignment.description }}</p>
 <p>Due: {{ assignment.due_date.strftime('%Y-%m-%d %H:%M') if assignment.due_date else 'N/A' }}</p>
 {% if assignment.solution_file_path %}
@@ -14,7 +14,7 @@
     <p>You may submit once. Please ensure your file is final before uploading.</p>
     <form method="POST" action="{{ url_for('submit_assignment', assignment_id=assignment.id) }}" enctype="multipart/form-data">
         <input type="file" name="file" accept="application/pdf, text/*" required>
-        <button type="submit">Submit Assignment</button>
+        <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" type="submit">Submit Assignment</button>
     </form>
 {% endif %}
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,33 +4,47 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SynapseAI</title>
+    <!-- Material Design Lite -->
+    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 </head>
 <body>
-    <nav>
-        <a href="{{ url_for('index') }}">Home</a>
-        {% if session.user_id %}
-            {% if session.role == 'master' %}
-                <a href="{{ url_for('master_dashboard') }}">Dashboard</a>
-            {% else %}
-                <a href="{{ url_for('pupil_dashboard') }}">Dashboard</a>
-            {% endif %}
-            <a href="{{ url_for('logout') }}">Logout</a>
-        {% else %}
-            <a href="{{ url_for('login') }}">Login with Google</a>
-        {% endif %}
-    </nav>
-    <div class="container">
-        {% with messages = get_flashed_messages() %}
-            {% if messages %}
-                <ul class="flashes">
-                {% for msg in messages %}
-                    <li>{{ msg }}</li>
-                {% endfor %}
-                </ul>
-            {% endif %}
-        {% endwith %}
-        {% block content %}{% endblock %}
+    <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+        <header class="mdl-layout__header">
+            <div class="mdl-layout__header-row">
+                <span class="mdl-layout-title">SynapseAI</span>
+                <div class="mdl-layout-spacer"></div>
+                <nav class="mdl-navigation">
+                    <a class="mdl-navigation__link" href="{{ url_for('index') }}">Home</a>
+                    {% if session.user_id %}
+                        {% if session.role == 'master' %}
+                            <a class="mdl-navigation__link" href="{{ url_for('master_dashboard') }}">Dashboard</a>
+                        {% else %}
+                            <a class="mdl-navigation__link" href="{{ url_for('pupil_dashboard') }}">Dashboard</a>
+                        {% endif %}
+                        <a class="mdl-navigation__link" href="{{ url_for('logout') }}">Logout</a>
+                    {% else %}
+                        <a class="mdl-navigation__link" href="{{ url_for('login') }}">Login with Google</a>
+                    {% endif %}
+                </nav>
+            </div>
+        </header>
+        <main class="mdl-layout__content">
+            <div class="page-content container">
+                {% with messages = get_flashed_messages() %}
+                    {% if messages %}
+                        <ul class="flashes">
+                        {% for msg in messages %}
+                            <li>{{ msg }}</li>
+                        {% endfor %}
+                        </ul>
+                    {% endif %}
+                {% endwith %}
+                {% block content %}{% endblock %}
+            </div>
+        </main>
     </div>
 </body>
 </html>

--- a/templates/edit_assignment.html
+++ b/templates/edit_assignment.html
@@ -1,13 +1,19 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Edit Assignment: {{ assignment.title }}</h2>
+<h2 class="mdl-typography--display-1">Edit Assignment: {{ assignment.title }}</h2>
 <form method="POST" enctype="multipart/form-data">
-    <input type="text" name="title" value="{{ assignment.title }}" required><br>
-    <textarea name="description">{{ assignment.description }}</textarea><br>
-    <input type="datetime-local" name="due_date" value="{{ assignment.due_date.strftime('%Y-%m-%dT%H:%M') if assignment.due_date else '' }}"><br>
-    <label>Solution File (recommended for best results, optional)</label>
+    <div class="mdl-textfield mdl-js-textfield">
+        <input class="mdl-textfield__input" type="text" name="title" id="edit_title" value="{{ assignment.title }}" required>
+        <label class="mdl-textfield__label" for="edit_title">Title</label>
+    </div><br>
+    <div class="mdl-textfield mdl-js-textfield">
+        <textarea class="mdl-textfield__input" name="description" id="edit_description">{{ assignment.description }}</textarea>
+        <label class="mdl-textfield__label" for="edit_description">Description</label>
+    </div><br>
+    <input class="mdl-textfield__input" type="datetime-local" name="due_date" value="{{ assignment.due_date.strftime('%Y-%m-%dT%H:%M') if assignment.due_date else '' }}"><br>
+    <label class="mdl-textfield">Solution File (optional)</label>
     <input type="file" name="solution" accept="application/pdf, text/*"><br>
-    <button type="submit">Save</button>
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" type="submit">Save</button>
 </form>
 {% if assignment.solution_file_path %}
 <p>Current solution: <a href="{{ url_for('uploaded_file', filename=assignment.solution_file_path.split('/')[-1]) }}">Download</a></p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Welcome to SynapseAI</h1>
+<h1 class="mdl-typography--display-2">Welcome to SynapseAI</h1>
 {% if not session.user_id %}
-    <p>Please <a href="{{ url_for('login') }}">login with Google</a> to continue.</p>
+    <p>Please
+        <a class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" href="{{ url_for('login') }}">Login with Google</a>
+        to continue.
+    </p>
 {% endif %}
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Login</h2>
-<a href="{{ url_for('login') }}">Sign in with Google</a>
+<h2 class="mdl-typography--display-1">Login</h2>
+<a class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" href="{{ url_for('login') }}">Sign in with Google</a>
 {% endblock %}

--- a/templates/master_dashboard.html
+++ b/templates/master_dashboard.html
@@ -1,14 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Your Course Spaces</h2>
-<ul>
+<h2 class="mdl-typography--display-1">Your Course Spaces</h2>
+<ul class="mdl-list">
     {% for space in spaces %}
-        <li><a href="{{ url_for('space_detail', space_id=space.id) }}">{{ space.name }}</a> (Code: {{ space.unique_code }})</li>
+        <li class="mdl-list__item">
+            <span class="mdl-list__item-primary-content">
+                <a href="{{ url_for('space_detail', space_id=space.id) }}">{{ space.name }}</a>
+                <span class="mdl-list__item-sub-title">Code: {{ space.unique_code }}</span>
+            </span>
+        </li>
     {% endfor %}
 </ul>
-<h3>Create New Space</h3>
+<h3 class="mdl-typography--title">Create New Space</h3>
 <form method="POST" action="{{ url_for('create_space') }}">
-    <input type="text" name="name" placeholder="Space Name" required>
-    <button type="submit">Create</button>
+    <div class="mdl-textfield mdl-js-textfield">
+        <input class="mdl-textfield__input" type="text" name="name" id="space_name" required>
+        <label class="mdl-textfield__label" for="space_name">Space Name</label>
+    </div>
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" type="submit">Create</button>
 </form>
 {% endblock %}

--- a/templates/pupil_dashboard.html
+++ b/templates/pupil_dashboard.html
@@ -1,14 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Your Joined Spaces</h2>
-<ul>
+<h2 class="mdl-typography--display-1">Your Joined Spaces</h2>
+<ul class="mdl-list">
     {% for space in spaces %}
-        <li><a href="{{ url_for('space_detail', space_id=space.id) }}">{{ space.name }}</a> (Code: {{ space.unique_code }})</li>
+        <li class="mdl-list__item">
+            <span class="mdl-list__item-primary-content">
+                <a href="{{ url_for('space_detail', space_id=space.id) }}">{{ space.name }}</a>
+                <span class="mdl-list__item-sub-title">Code: {{ space.unique_code }}</span>
+            </span>
+        </li>
     {% endfor %}
 </ul>
-<h3>Join a Space</h3>
+<h3 class="mdl-typography--title">Join a Space</h3>
 <form method="POST" action="{{ url_for('join_space') }}">
-    <input type="text" name="code" placeholder="Enter Code" required>
-    <button type="submit">Join</button>
+    <div class="mdl-textfield mdl-js-textfield">
+        <input class="mdl-textfield__input" type="text" name="code" id="join_code" required>
+        <label class="mdl-textfield__label" for="join_code">Enter Code</label>
+    </div>
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" type="submit">Join</button>
 </form>
 {% endblock %}

--- a/templates/space_detail.html
+++ b/templates/space_detail.html
@@ -1,27 +1,39 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Space: {{ space.name }}</h2>
-<ul>
+<h2 class="mdl-typography--display-1">Space: {{ space.name }}</h2>
+<ul class="mdl-list">
     {% for assignment in assignments %}
-        <li>
-            <a href="{{ url_for('assignment_detail', assignment_id=assignment.id) }}">{{ assignment.title }}</a>
+        <li class="mdl-list__item">
+            <span class="mdl-list__item-primary-content">
+                <a href="{{ url_for('assignment_detail', assignment_id=assignment.id) }}">{{ assignment.title }}</a>
+            </span>
             {% if session.role == 'master' %}
-                - <a href="{{ url_for('edit_assignment', assignment_id=assignment.id) }}">Edit</a>
+                <span class="mdl-list__item-secondary-action">
+                    <a class="mdl-button mdl-js-button mdl-button--icon" href="{{ url_for('edit_assignment', assignment_id=assignment.id) }}">
+                        <i class="material-icons">edit</i>
+                    </a>
+                </span>
             {% endif %}
         </li>
     {% else %}
-        <li>No assignments yet.</li>
+        <li class="mdl-list__item">No assignments yet.</li>
     {% endfor %}
 </ul>
 {% if session.role == 'master' %}
-<h3>Create Assignment</h3>
+<h3 class="mdl-typography--title">Create Assignment</h3>
 <form method="POST" action="{{ url_for('create_assignment', space_id=space.id) }}" enctype="multipart/form-data">
-    <input type="text" name="title" placeholder="Title" required><br>
-    <textarea name="description" placeholder="Description"></textarea><br>
-    <input type="datetime-local" name="due_date"><br>
-    <label>Solution File (recommended for best results, optional)</label>
+    <div class="mdl-textfield mdl-js-textfield">
+        <input class="mdl-textfield__input" type="text" name="title" id="title" required>
+        <label class="mdl-textfield__label" for="title">Title</label>
+    </div><br>
+    <div class="mdl-textfield mdl-js-textfield">
+        <textarea class="mdl-textfield__input" name="description" id="description"></textarea>
+        <label class="mdl-textfield__label" for="description">Description</label>
+    </div><br>
+    <input class="mdl-textfield__input" type="datetime-local" name="due_date"><br>
+    <label class="mdl-textfield">Solution File (optional)</label>
     <input type="file" name="solution" accept="application/pdf, text/*"><br>
-    <button type="submit">Create</button>
+    <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" type="submit">Create</button>
 </form>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- integrate Material Design Lite via CDN
- restyle base layout and templates using MDL components
- add minimal CSS tweaks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685135320460832b9a22b6dedcd880b1